### PR TITLE
TE-7741 Updated dependencies.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer-plugin-api": ">1.1",
+        "composer-plugin-api": "^1.1.0 || ^2.0.0",
         "php": ">=7.2"
     },
     "require-dev": {
-        "composer/composer": ">1.1.0"
+        "composer/composer": "^1.1.0 || ^2.0.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Spryker/Composer/Plugin/MergePlugin.php
+++ b/src/Spryker/Composer/Plugin/MergePlugin.php
@@ -13,6 +13,7 @@ use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\Factory;
 use Composer\Installer;
 use Composer\Installer\PackageEvent;
+use Composer\Installer\PackageEvents;
 use Composer\IO\IOInterface;
 use Composer\Package\RootPackageInterface;
 use Composer\Plugin\PluginInterface;
@@ -88,7 +89,7 @@ class MergePlugin implements PluginInterface, EventSubscriberInterface
             ScriptEvents::PRE_AUTOLOAD_DUMP => ['preAutoloadDump', static::CALLBACK_PRIORITY],
             ScriptEvents::POST_INSTALL_CMD => ['postInstallOrUpdate', static::CALLBACK_PRIORITY],
             ScriptEvents::POST_UPDATE_CMD => ['postInstallOrUpdate', static::CALLBACK_PRIORITY],
-            ScriptEvents::POST_PACKAGE_INSTALL => ['postPackageInstall', static::CALLBACK_PRIORITY],
+            PackageEvents::POST_PACKAGE_INSTALL => ['postPackageInstall', static::CALLBACK_PRIORITY],
         ];
     }
 


### PR DESCRIPTION
- Developer(s): @stereomon

- Ticket: https://spryker.atlassian.net/browse/TE-7741

- Academy PR: ACADEMY_URL_HERE

- Release Group: https://release.spryker.com/release-groups/view/3079


#### Documentation

- [ ] Functional documentation provided or in progress?
- [ ] Integration guide for projects provided or not needed?
- [ ] Migration guides for all contained majors provided or not needed?

#### Release Table

   Module                | Release Type         | Constraint Updates         |
   :--------------------- | :------------------------ | :--------------------- |
   ComposerMergePlugin   | major (currently 0.0.x)  |                       |

-----------------------------------------

#### Module ComposerMergePlugin

##### Change log

Initial Release

- Internal composer-plugin that is capable of merging Spryker's autoload and autoload-dev from non-split modules.

